### PR TITLE
feature/remove-dns-records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v0.1.3
 
 * Added action/workflow to delete dns record and all associated related records and PTR records.
+* Added action/workflow to return FQDN based on name and DNS Zone Reference.
 * Added action/workflow to test if a hostname is available or not
 * Added action/workflow to test credentials against the Men&Mice server.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.1.3
+
+* Added action/workflow to delete dns record and all associated related records and PTR records.
+* Added action/workflow to test if a hostname is available or not
+* Added action/workflow to test credentials against the Men&Mice server.
+
 ## v0.1.2
 
 * Added support for self-signed SSL certificates.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ result:
 
 In addition to the actions above there are a few additional actions that we will discuss here.
 
-`remove_dns_record`: Action will find the DNS record and get any related records(CNAME, AAAA, etc) tied to that record and the pointer record. Then removes all the records so that there are no orphaned records left behind. Once the records are removed we then flush the cache for just the records that were removed.
+`remove_dns_record`: Action will find the DNS record and get any related records(CNAME, AAAA, etc) tied to that record and the pointer record. Then remove all the records so that there are no orphaned records left behind. Once the records are removed we then flush the cache for just the records that were removed.
 ``` shell
 $ st2 run menandmice.remove_dns_record server=menandmice.domain.tld username=administrator password=xxx name="test-name" dns_domain="domain.tld" ip_address='1.1.1.1'
 .................

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ result:
 
 ## <a name="UsageAdditionalActions"></a> Usage - Additional Actions
 
-In addition to the actions above there are a few additional actions that we will discuss here.
+In addition to the auto-generated actions described above, there are a handful of higher-level workflow actions that implement common functionality.
 
 `remove_dns_record`: Action will find the DNS record and get any related records(CNAME, AAAA, etc) tied to that record and the pointer record. Then remove all the records so that there are no orphaned records left behind. Once the records are removed we then flush the cache for just the records that were removed.
 ``` shell
@@ -309,6 +309,23 @@ parameters:
   server: menandmice.domain.tld
   username: administrator
 status: succeeded
+```
+
+`resolve_fqdn`: Action accepts a name and a DNS Zone reference. Action will find the zone and append that to the name givin returning a FQDN.
+``` shell
+$ st2 run menandmice.resolve_fqdn server=menandmice.domain.tld username=administrator password=xxx name="test-name" dns_zone_ref='{#4-#4}'
+....
+id: 5ccaed9149b3d27e56a56d07
+action.ref: menandmice.resolve_fqdn
+parameters:
+  dns_zone_ref: '{#4-#4}'
+  name: test-name
+  password: '***'
+  server: menandmice.domain.tld
+  username: administrator
+status: succeeded
+start_timestamp: Thu, 02 May 2019 13:16:01 UTC
+end_timestamp: Thu, 02 May 2019 13:16:07 UTC
 ```
 
 `test_credentials`: Action will attempt to log into the Men & Mice Server with the credential provided to test if logins are successfull or failed.

--- a/actions/remove_dns_record.yaml
+++ b/actions/remove_dns_record.yaml
@@ -1,0 +1,50 @@
+---
+description: "This is a workflow to delete DNS records out of Men&Mice"
+enabled: true
+runner_type: "mistral-v2"
+entry_point: workflows/remove_dns_record.yaml
+name: remove_dns_record
+pack: menandmice
+parameters:
+  connection:
+    type: string
+    description: "Name of <connection> from this pack's configuration that specifies how to connect to a Men&Mice server."
+    required: false
+  server:
+    type: string
+    description: "Optional override of the Men&Mice server in <connection> (required if <connection> is not specified)."
+    required: false
+  username:
+    type: string
+    description: "Optional override of the Men&Mice username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
+    required: false
+  password:
+    type: string
+    description: "Optional override of the Men&Mice password in <connection>. (required if <connection> is not specified)"
+    required: false
+    secret: true
+  port:
+    type: integer
+    description: "Optional override of the Men&Mice port in <connection>."
+    required: false
+  transport:
+    type: string
+    description: "Optional override of the Men&Mice transport in <connection>."
+    required: false
+  session:
+    type: string
+    required: false
+    description: "Login session cookie. If empty then username/password will be used to login prior to running this operation"
+    default: ''
+  dns_domain:
+    type: string
+    description: "DNS name of the record eg. 'domain.tld'"
+    required: true
+  ip_address:
+    type: string
+    description: "IP address of the DNS Record"
+    required: true
+  name:
+    type: string
+    description: "Name of the DNS record"
+    required: true

--- a/actions/resolve_fqdn.yaml
+++ b/actions/resolve_fqdn.yaml
@@ -1,0 +1,47 @@
+---
+description: "Create an fqdn from the Men&Mice name and Zone info"
+enabled: true
+entry_point: workflows/resolve_fqdn.yaml
+name: resolve_fqdn
+pack: menandmice
+runner_type: "mistral-v2"
+parameters:
+  connection:
+    type: string
+    description: "Name of <connection> from this pack's configuration that specifies how to connect to a Men&Mice server."
+    required: false
+  server:
+    type: string
+    description: "Optional override of the Men&Mice server in <connection> (required if <connection> is not specified)."
+    required: false
+  username:
+    type: string
+    description: "Optional override of the Men&Mice username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
+    required: false
+  password:
+    type: string
+    description: "Optional override of the Men&Mice password in <connection>. (required if <connection> is not specified)"
+    required: false
+    secret: true
+  port:
+    type: integer
+    description: "Optional override of the Men&Mice port in <connection>."
+    required: false
+  transport:
+    type: string
+    description: "Optional override of the Men&Mice transport in <connection>."
+    required: false
+  session:
+    type: string
+    required: false
+    description: "Login session cookie. If empty then username/password will be used to login prior to running this operation"
+    default: ''
+  dns_zone_ref:
+    type: string
+    description: "Men&Mice Zone Ref"
+    required: true
+  name:
+    type: string
+    description: "Name of the DNS record"
+    required: true
+

--- a/actions/test_credentials.yaml
+++ b/actions/test_credentials.yaml
@@ -1,0 +1,33 @@
+---
+description: "Test the credentials to login to Men&Mice"
+enabled: true
+runner_type: "mistral-v2"
+entry_point: workflows/test_credentials.yaml
+name: test_credentials
+pack: menandmice
+parameters:
+  connection:
+    type: string
+    description: "Name of <connection> from this pack's configuration that specifies how to connect to a Men&Mice server."
+    required: false
+  server:
+    type: string
+    description: "Optional override of the Men&Mice server in <connection> (required if <connection> is not specified)."
+    required: false
+  username:
+    type: string
+    description: "Optional override of the Men&Mice username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
+    required: false
+  password:
+    type: string
+    description: "Optional override of the Men&Mice password in <connection>. (required if <connection> is not specified)"
+    required: false
+    secret: true
+  port:
+    type: integer
+    description: "Optional override of the Men&Mice port in <connection>."
+    required: false
+  transport:
+    type: string
+    description: "Optional override of the Men&Mice transport in <connection>."
+    required: false

--- a/actions/test_hostname.yaml
+++ b/actions/test_hostname.yaml
@@ -1,0 +1,46 @@
+---
+description: "Test hostname to see if it is already in use in Men&Mice"
+enabled: true
+runner_type: "mistral-v2"
+entry_point: workflows/test_hostname.yaml
+name: test_hostname
+pack: menandmice
+parameters:
+  connection:
+    type: string
+    description: "Name of <connection> from this pack's configuration that specifies how to connect to a Men&Mice server."
+    required: false
+  server:
+    type: string
+    description: "Optional override of the Men&Mice server in <connection> (required if <connection> is not specified)."
+    required: false
+  username:
+    type: string
+    description: "Optional override of the Men&Mice username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
+    required: false
+  password:
+    type: string
+    description: "Optional override of the Men&Mice password in <connection>. (required if <connection> is not specified)"
+    required: false
+    secret: true
+  port:
+    type: integer
+    description: "Optional override of the Men&Mice port in <connection>."
+    required: false
+  transport:
+    type: string
+    description: "Optional override of the Men&Mice transport in <connection>."
+    required: false
+  session:
+    type: string
+    required: false
+    description: "Login session cookie. If empty then username/password will be used to login prior to running this operation"
+    default: ''
+  dns_domain:
+    type: string
+    description: "DNS name of the record eg. 'domain.tld'"
+    required: true
+  hostname:
+    type: string
+    description: "hostname of the DNS record being tested"
+    required: true

--- a/actions/workflows/remove_dns_record.yaml
+++ b/actions/workflows/remove_dns_record.yaml
@@ -1,0 +1,153 @@
+version: '2.0'
+
+menandmice.remove_dns_record:
+  description: >
+    This is a workflow to delete DNS records out of Men&Mice
+  type: direct
+  input:
+    - connection
+    - server
+    - username
+    - password
+    - port
+    - transport
+    - session
+    - dns_domain
+    - ip_address
+    - name
+
+  tasks:
+    main:
+      action: std.noop
+      on-success:
+        - login: "{{ _.session == '' }}"
+        - get_dns_servers: "{{ _.session != '' }}"
+
+    login:
+      action: menandmice.login
+      input:
+        connection: "{{ _.connection }}"
+        server: "{{ _.server }}"
+        username: "{{ _.username }}"
+        password: "{{ _.password }}"
+        port: "{{ _.port }}"
+        transport: "{{ _.transport }}"
+      publish:
+        session: "{{ task('login').result.result.session }}"
+      on-success:
+        - get_dns_servers
+
+    # Gets all DNS servers
+    get_dns_servers:
+      action: menandmice.get_dns_servers
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+      publish:
+        # note: flatten() is needed because otherwise it's an array of arrays
+        dns_server_refs: <% task(get_dns_servers).result.result.dnsServers.dnsServer.ref.flatten() %>
+      on-success:
+        - get_dns_zone
+
+    get_dns_zone:
+      action: menandmice.get_dns_zones
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        filter: "type:^Master$ name:^{{ _.dns_domain }}.$"
+      publish:
+        dns_zone_ref: "{{ task('get_dns_zone').result.result.dnsZones.dnsZone[0].ref }}"
+      on-success:
+        - get_dns_record
+
+    # Does not allow duplicates to be added
+    get_dns_record:
+      action: menandmice.get_dns_records
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        dns_zone_ref: "{{ _.dns_zone_ref }}"
+        filter: "name:{{ _.name }} AND type:A"
+      publish:
+        dns_record_ref: "{{ task('get_dns_record').result.result.dnsRecords.dnsRecord[0].ref }}"
+        dns_record: "{{ task('get_dns_record').result.result.dnsRecords.dnsRecord[0] }}"
+      on-success:
+        - get_related_records
+
+    # Can potentially have many records or None
+    get_related_records:
+      action: menandmice.get_related_dns_records
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        dns_record_ref: "{{ _.dns_record_ref }}"
+      publish:
+        dns_releated_records_refs: "{{ task('get_related_records').result.result | map(attribute='ref') | list if task('get_related_records').result.result != None else [] }}"
+        dns_releated_records: "{{ task('get_related_records').result.result if task('get_related_records').result.result != None else [] }}"
+      on-success:
+        - get_dns_ptr_record
+
+    # Does not allow duplicates to be added
+    get_dns_ptr_record:
+      action: menandmice.get_dnsptr_records
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        address: "{{ _.ip_address }}"
+        dns_zone_ref: "{{ _.dns_zone_ref }}"
+      publish:
+        dns_ptr_ref: "{{ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0].ref }}"
+        ptr_record: "{{ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0] }}"
+      on-success:
+        - merge_records
+
+    merge_records:
+      action: std.noop
+      publish:
+        records_to_remove: "{{ [ _.dns_record_ref, _.dns_ptr_ref ] + _.dns_releated_records_refs }}"
+        dns_records_to_flush: "{{ [ _.dns_record, _.ptr_record ] + _.dns_releated_records }}"
+      on-success:
+        - resolve_fqdn
+
+    # DNS records only come in with the hostname. We need to convert to FQDNs
+    resolve_fqdn:
+      with-items: "record in {{ _.dns_records_to_flush }}"
+      action: menandmice.resolve_fqdn
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        dns_zone_ref: "{{ _.record.dnsZoneRef }}"
+        name: "{{ _.record.name }}"
+      publish:
+        # This is done in YAQL because it automatically returns as an array
+        entries_to_flush: <% task('resolve_fqdn').result.fqdn %>
+      on-success:
+        - remove_dns_records
+
+    remove_dns_records:
+      action: menandmice.remove_objects
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        obj_refs:
+          ref: "{{ _.records_to_remove }}"
+      on-success:
+        - flush_dns_cache
+
+    flush_dns_cache:
+      with-items: "entry in {{ _.entries_to_flush }}"
+      action: menandmice.flush_from_cache_on_dns_servers
+      input:
+        session: "{{ _.session }}"
+        server: "{{ _.server }}"
+        transport: "{{ _.transport }}"
+        dns_server_refs:
+          ref: "{{ _.dns_server_refs }}"
+        entry: "{{ _.entry }}"

--- a/actions/workflows/resolve_fqdn.yaml
+++ b/actions/workflows/resolve_fqdn.yaml
@@ -1,0 +1,50 @@
+version: '2.0'
+
+menandmice.resolve_fqdn:
+  description: >
+    Create an fqdn from the M&M name and Zone info
+  type: direct
+  input:
+    - connection
+    - server
+    - username
+    - password
+    - port
+    - transport
+    - session
+    - dns_zone_ref
+    - name
+
+  output:
+    fqdn: "{{ _.fqdn }}"
+
+  tasks:
+    main:
+      action: std.noop
+      on-success:
+        - login: "{{ _.session == '' }}"
+        - get_dns_zone: "{{ _.session != '' }}"
+
+    login:
+      action: menandmice.login
+      input:
+        connection: "{{ _.connection }}"
+        server: "{{ _.server }}"
+        username: "{{ _.username }}"
+        password: "{{ _.password }}"
+        port: "{{ _.port }}"
+        transport: "{{ _.transport }}"
+      publish:
+        session: "{{ task('login').result.result.session }}"
+      on-success:
+        - get_dns_zone
+
+    get_dns_zone:
+      action: menandmice.get_dns_zone
+      input:
+        server: "{{ _.server }}"
+        session: "{{ _.session }}"
+        transport: "{{ _.transport }}"
+        dns_zone_ref: "{{ _.dns_zone_ref }}"
+      publish:
+        fqdn: "{{ _.name + '.' + task('get_dns_zone').result.result.name }}"

--- a/actions/workflows/test_credentials.yaml
+++ b/actions/workflows/test_credentials.yaml
@@ -1,0 +1,39 @@
+version: '2.0'
+
+menandmice.test_credentials:
+  description: >
+    Test the credentials to login to Men&Mice
+  type: direct
+  input:
+    - connection
+    - server
+    - username
+    - password
+    - port
+    - transport
+
+  output:
+    result: "{{ _.result }}"
+    data:
+      server: "{{ _.server }}"
+      username: "{{ _.username }}"
+  output-on-error:
+    result: "{{ _.result }}"
+    data:
+      server: "{{ _.server }}"
+      username: "{{ _.username }}"
+
+  tasks:
+    main:
+      action: menandmice.login
+      input:
+        connection: "{{ _.connection }}"
+        server: "{{ _.server }}"
+        username: "{{ _.username }}"
+        password: "{{ _.password }}"
+        port: "{{ _.port }}"
+        transport: "{{ _.transport }}"
+      publish:
+        result: "{{ task('main').result }}"
+      publish-on-error:
+        result: "{{ task('main').result }}"

--- a/actions/workflows/test_hostname.yaml
+++ b/actions/workflows/test_hostname.yaml
@@ -1,0 +1,61 @@
+version: '2.0'
+
+menandmice.test_hostname:
+  description: >
+    Test hostname to see if it is already in use in Men&Mice
+  type: direct
+  input:
+    - connection
+    - server
+    - username
+    - password
+    - port
+    - transport
+    - session
+    - dns_domain
+    - hostname
+
+  tasks:
+    main:
+      action: std.noop
+      on-success:
+        - login: "{{ _.session == '' }}"
+        - get_dns_zone: "{{ _.session != '' }}"
+
+    login:
+      action: menandmice.login
+      input:
+        connection: "{{ _.connection }}"
+        server: "{{ _.server }}"
+        username: "{{ _.username }}"
+        password: "{{ _.password }}"
+        port: "{{ _.port }}"
+        transport: "{{ _.transport }}"
+      publish:
+        session: "{{ task('login').result.result.session }}"
+      on-success:
+        - get_dns_zone
+
+    get_dns_zone:
+      action: menandmice.get_dns_zones
+      input:
+        session: "{{ _.session }}"
+        server: "{{ _.server }}"
+        transport: "{{ _.transport }}"
+        filter: "type:master name:^{{ _.dns_domain }}.$"
+      publish:
+        dns_zone_ref: "{{ task('get_dns_zone').result.result.dnsZones.dnsZone[0].ref }}"
+      on-success:
+        - check_dns_name
+
+    check_dns_name:
+      action: menandmice.get_dns_records
+      input:
+        session: "{{ _.session }}"
+        server: "{{ _.server }}"
+        transport: "{{ _.transport }}"
+        dns_zone_ref: "{{ _.dns_zone_ref }}"
+        filter: "name:{{ _.hostname }}"
+      on-complete:
+        - fail: "{{ task('check_dns_name').result.result.totalResults > 0 }}"
+        - succeed: "{{ task('check_dns_name').result.result.totalResults == 0 }}"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,12 +2,12 @@
 ref: menandmice
 name: menandmice
 description: StackStorm integration pack for working with the Men&Mice IPAM system.
-keywords: 
+keywords:
     - menandmice
     - men
     - mice
     - ipam
     - dns
-version: 0.1.2
+version: 0.1.3
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION
Added new actions and workflows to remove a DNS Record and all its related records and PTR records since those are not cleaned up automatically. Added new actions and workflows to test if a hostname is available for use. Added new actions and workflows to test credentials against the server. Iterated pack version and added to changelog.