### PR TITLE
Fixing filter operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.0.2
+
+* Fixed issue with test_credentials and remove_dns_record where name filter was not correct.
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## v1.0.1
 
 * Fixed issue with test_credentials not exiting with fail.

--- a/actions/workflows/remove_dns_record.yaml
+++ b/actions/workflows/remove_dns_record.yaml
@@ -76,7 +76,7 @@ tasks:
       session: "{{ ctx().session }}"
       transport: "{{ ctx().transport }}"
       dns_zone_ref: "{{ ctx().dns_zone_ref }}"
-      filter: name:{{ ctx().name }} AND type:A
+      filter: name={{ ctx().name }} AND type:A
     next:
       - when: "{{ succeeded() }}"
         publish:

--- a/actions/workflows/test_hostname.yaml
+++ b/actions/workflows/test_hostname.yaml
@@ -62,7 +62,7 @@ tasks:
       server: "{{ ctx().server }}"
       transport: "{{ ctx().transport }}"
       dns_zone_ref: "{{ ctx().dns_zone_ref }}"
-      filter: name:{{ ctx().hostname }}
+      filter: name={{ ctx().hostname }}
     next:
       - when: "{{ result().result.totalResults > 0 }}"
         do:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - mice
   - ipam
   - dns
-version: 1.0.1
+version: 1.0.2
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
Changing Filter operator from `:` to `=` because `:` accepts anything after the name as well

Not working ex:
```
# st2 run menandmice.get_dns_records
id: 5e3899c407afa7203168ec1d
status: succeeded (1s elapsed)
parameters:
  dns_zone_ref: '{#4-#1806}'
  filter: name:test
  server: test.domain.tld
  session: test-session
  transport: https
result:
  exit_code: 0
  result:
    dnsRecords:
      dnsRecord:
      - aging: null
        comment: null
        data: 192.168.1.48
        dnsZoneRef: '{#4-#1806}'
        enabled: true
        name: test1
        ref: '{#13-#235489}'
        ttl: '3600'
        type: A
      - aging: null
        comment: null
        data: 192.168.2.48
        dnsZoneRef: '{#4-#1806}'
        enabled: true
        name: test2
        ref: '{#13-#235490}'
        ttl: '3600'
        type: A
    offset: null
    totalResults: 2
```

Working EX:
```
# st2 run menandmice.get_dns_records
id: 5e3899c407afa7203168ec1d
status: succeeded (1s elapsed)
parameters:
  dns_zone_ref: '{#4-#1806}'
  filter: name=test
  server: test.domain.tld
  session: test-session
  transport: https
result:
  exit_code: 0
  result:
    dnsRecords: null
    offset: null
    totalResults: 0
```